### PR TITLE
Supply DoctrineProfilerExtension with getName() implementation

### DIFF
--- a/Twig/DoctrineProfilerExtension.php
+++ b/Twig/DoctrineProfilerExtension.php
@@ -28,4 +28,12 @@ class DoctrineProfilerExtension extends \Twig_Extension
     {
         return preg_replace('/SELECT.+FROM/', 'SELECT […] FROM', $sql);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return get_class($this);
+    }
 }


### PR DESCRIPTION
Since Twig 1.26 getName() was marked as depracated in \Twig_ExtensionInterface. Alongside, getName() implementation was added to abstract class \Twig_Extension.

For Twig versions less than 1.26 this implementation is missing. Symfony ~2.6 still supports Twig >=1.12.3.