### PR TITLE
Fix support for symfony 4.0

### DIFF
--- a/DataCollector/QueryCollector.php
+++ b/DataCollector/QueryCollector.php
@@ -213,6 +213,14 @@ class QueryCollector extends DataCollector
     }
 
     /**
+     * @return void
+     */
+    public function reset()
+    {
+        $this->data = array();
+    }
+
+    /**
      * Returns "internal" namespaces for query source selection
      *
      * @return array

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": ">=5.4",
         "doctrine/orm": "~2.4",
         "doctrine/doctrine-bundle": "~1.2",
-        "symfony/framework-bundle": "~2.6 || ~3.0"
+        "symfony/framework-bundle": "~2.6 || ~3.0 || ~4.0",
+        "symfony/stopwatch": "~2.6 || ~3.0 || ~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
At the moment, updating symfony to 4.0 results error because DataCollector does not implement `reset()` method from `DataCollectorInterface`. Error occurred because of not defined version of http-kernel package and only symfony/framework, which allows both version (3 and 4).
Also, stopwatch no longer is in default symfony/framework dependencies so I've added it.