### PR TITLE
New twig template aliasing

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,7 +12,7 @@
       <factory class="Pixers\DoctrineProfilerBundle\ORM\EntityManager" method="create"/>
     </service>
     <service id="pixers_doctrine_profiler.data_collector" class="Pixers\DoctrineProfilerBundle\DataCollector\QueryCollector" public="false">
-      <tag name="data_collector" template="PixersDoctrineProfilerBundle:Collector:profiler.html.twig" id="doctrine_profiler"/>
+      <tag name="data_collector" template="@PixersDoctrineProfiler/Collector/profiler.html.twig" id="doctrine_profiler"/>
       <argument type="service" id="pixers_doctrine_profiler.logger"/>
       <argument type="service" id="debug.stopwatch"/>
     </service>

--- a/Resources/views/Collector/profiler.html.twig
+++ b/Resources/views/Collector/profiler.html.twig
@@ -3,17 +3,17 @@
 {% block head %}
     {{ parent() }}
     <style type="text/css">
-        {{ include('PixersDoctrineProfilerBundle:Collector:styles.css.twig') }}
+        {{ include('@PixersDoctrineProfiler/Collector/styles.css.twig') }}
     </style>
     <script type="text/javascript">
-        {{ include('PixersDoctrineProfilerBundle:Collector:scripts.js.twig') }}
+        {{ include('@PixersDoctrineProfiler/Collector/scripts.js.twig') }}
     </script>
 {% endblock head %}
 
 {% block toolbar %}
     {% if collector.count > 0 %}
         {% set icon %}
-            <span class="icon">{{ include('PixersDoctrineProfilerBundle:Collector:icon.svg.twig') }}</span>
+            <span class="icon">{{ include('@PixersDoctrineProfiler/Collector/icon.svg.twig') }}</span>
         {% endset %}
 
         {% set text %}
@@ -41,7 +41,7 @@
 
 {% block menu %}
     <span class="label {{ collector.count==0 ? 'disabled' : '' }}">
-        <span class="icon">{{ include('PixersDoctrineProfilerBundle:Collector:icon.svg.twig') }}</span>
+        <span class="icon">{{ include('@PixersDoctrineProfiler/Collector/icon.svg.twig') }}</span>
         <strong>Doctrine profiler</strong>
     </span>
 {% endblock %}
@@ -94,7 +94,7 @@
         {% set nodes = collector.flattenCallGraph.children %}
         {% set valueAccessor = collector.nodeValueAccessor %}
         <div class="tree-wrapper">
-            {% include 'PixersDoctrineProfilerBundle:Collector:tree.html.twig' with {
+            {% include '@PixersDoctrineProfiler/Collector/tree.html.twig' with {
                 nodes: nodes,
                 valueAccessor: valueAccessor,
             } %}

--- a/Resources/views/Collector/styles.css.twig
+++ b/Resources/views/Collector/styles.css.twig
@@ -1,4 +1,4 @@
-{% include 'PixersDoctrineProfilerBundle:Collector:tree.css.twig' %}
+{% include '@PixersDoctrineProfiler/Collector/tree.css.twig' %}
 
 .sf-reset .traces {
     padding: 0 0 1em 1.5em;


### PR DESCRIPTION
Hi,
I installed your (very nice!) bundle in a fresh symfony 4 project and noticed that it uses symfony templating component syntax and it's no longer default for symfony 4.

Can we change it to syntax that is supported out of the box as proposed?