### PR TITLE
Drop support for old PHP and Symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
-  - hhvm
+  - 7.2
+  - 7.3
+  - nightly
 
 sudo: false
 
@@ -14,23 +13,16 @@ cache:
     - $HOME/.composer/cache
 
 env:
-  - SYMFONY_VERSION=2.8.*
+  matrix:
+    - SYMFONY_VERSION="2.8.*"
+    - SYMFONY_VERSION="3.4.*"
+    - SYMFONY_VERSION="4.1.*"
+    - SYMFONY_VERSION="4.2.*"
 
 matrix:
   fast_finish: true
-  include:
-    - php: 5.5
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 7.0
-      env: SYMFONY_VERSION=2.8.*
-    - php: 7.0
-      env: SYMFONY_VERSION=3.1.*
-    - php: 7.0
-      env: SYMFONY_VERSION=3.2.*
   allow_failures:
-    - php: hhvm
+    - php: nightly
 
 before_script:
   - curl -sS https://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
     "description": "PIXERS Doctrine profiler bundle",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.4",
-        "doctrine/orm": "~2.4",
-        "doctrine/doctrine-bundle": "~1.2",
-        "symfony/framework-bundle": "~2.6 || ~3.0 || ~4.0",
-        "symfony/stopwatch": "~2.6 || ~3.0 || ~4.0"
+        "php": ">=7.1",
+        "doctrine/orm": "~2.5",
+        "doctrine/doctrine-bundle": "~1.6",
+        "symfony/framework-bundle": "~2.8 || ~3.4 || ~4.1",
+        "symfony/stopwatch": "~2.8 || ~3.4 || ~4.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~5.0"
     },
     "authors": [
         {


### PR DESCRIPTION
Changes in this PR:
- Support PHP 7.1+ only
- Support Symfony 2.8+, 3.4+, 4.1+ only
- Drop HHVM support
- Update PHPUnit to `~5.0`
- Test against Symfony 2.8, 3.4, 4.1, 4.2 on PHP 7.1, 7.2, 7.3 in Travis CI - all currently supported versions

BTW Travis CI seems to not working.