### PR TITLE
Add link to display runnable query

### DIFF
--- a/Resources/views/Collector/profiler.html.twig
+++ b/Resources/views/Collector/profiler.html.twig
@@ -70,7 +70,7 @@
             <span class="value">{{ collector.count }}</span>
             <span class="label">Queries</span>
         </div>
-            
+
         <div class="metric">
             <span class="value">{{ collector.duplicatedcount }}</span>
             <span class="label">Duplicated queries</span>
@@ -80,7 +80,7 @@
             <span class="value">{{ (total_query_time * 1000)|round(2) }} ms</span>
             <span class="label">Query time</span>
         </div>
-        
+
         <div class="metric">
             <span class="value">{{ (total_hydration_time * 1000)|round }} ms</span>
             <span class="label">Hydration time</span>
@@ -121,6 +121,7 @@
         </thead>
         <tbody id="queries">
             {% for i, query in queries %}
+                {% set queryId = query.trace_hash~query.sql_hash %}
                 <tr id="query-{{ i }}" onclick="highlightRow(this)">
                     <td class="nowrap">{{ loop.index }}</td>
                     <td class="nowrap">{{ query.count }}</td>
@@ -153,8 +154,14 @@
                             <strong class="font-normal text-small">Parameters</strong>: {{ query.params|yaml_encode }}
                         </div>
                         <div class="text-small font-normal">
-                            <a href="#" class="text-small" onclick="openTree('[data-query={{ '"'~i~'"' }}]');return false;">Jump to callgraph</a>  &nbsp;&nbsp; 
+                            <a href="#" class="text-small" onclick="openTree('[data-query={{ '"'~i~'"' }}]');return false;">Jump to callgraph</a> &nbsp;&nbsp;
+                            <a href="#" onclick="Popup.load('#original-query-{{ queryId }}');return false;">View runnable query</a>&nbsp;&nbsp;
                             <a href="{{ path('_profiler', {panel: 'doctrine_profiler', token: token, page: 'trace', id: i}) }}" data-target-id="trace-{{ i }}" onclick="Popup.load(this.href);return false;">Show trace</a>
+                        </div>
+                        <div style="display:none" id="original-query-{{ queryId }}">
+                            <div class="queries-table">
+                                {{ (query.sql ~ ';')|doctrine_replace_query_parameters(query.params)|doctrine_pretty_query(true) }}
+                            </div>
                         </div>
                     </td>
                 </tr>
@@ -164,7 +171,7 @@
     {% endif %}
     <div class="popup__shadow" onclick="Popup.close()"></div>
     <div class="popup__window">
-        <a href="#" class="popup__close" onclick="Popup.close();return false;">&times;</a>    
+        <a href="#" class="popup__close" onclick="Popup.close();return false;">&times;</a>
         <div class="popup__content"></div>
     </div>
 {% endblock %}

--- a/Resources/views/Collector/tree.html.twig
+++ b/Resources/views/Collector/tree.html.twig
@@ -3,9 +3,9 @@
         <div class="tree__header">
             <div class="tree__col"><span></span>Info</div>
             {% for label in ['Count', 'Query time', 'Hydration time', 'Total time', 'Memory'] %}
-                <div 
-                    class="tree__col" 
-                    onclick="javascript:sortTable(this, {{ loop.index }}, 'tree-{{ id|default('root') }}', '.tree__row>.tree__col', 'ul')" 
+                <div
+                    class="tree__col"
+                    onclick="javascript:sortTable(this, {{ loop.index }}, 'tree-{{ id|default('root') }}', '.tree__row>.tree__col', 'ul')"
                     style="cursor: pointer"><span></span>{{ label }}
                 </div>
             {% endfor %}
@@ -40,15 +40,16 @@
                             <em>in {{ node.trace.file|format_file(node.trace.line) }}</em><br>
                         {% endif %}
                         {% if isLeaf %}
-                            <a href="#query-{{ queryId }}" class="text-small" onclick="highlightRow('#query-{{ queryId }}')">Jump to query</a> &nbsp;&nbsp; 
+                            <a href="#query-{{ queryId }}" class="text-small" onclick="highlightRow('#query-{{ queryId }}')">Jump to query</a> &nbsp;&nbsp;
                             <a href="#" onclick="Popup.load('#sql-{{ queryId }}');return false;" class="text-small">Show query</a> &nbsp;&nbsp;
+                            <a href="#" onclick="Popup.load('#original-query-{{ queryId }}');return false;" class="text-small">View runnable query</a> &nbsp;&nbsp;
                             <a href="{{ path('_profiler', {panel: 'doctrine_profiler', token: token, page: 'trace', id: queryId}) }}" class="text-small"  onclick="Popup.load(this.href);return false;">Show trace</a>
-                            <div style="display:none" id="sql-{{ queryId }}"> 
+                            <div style="display:none" id="sql-{{ queryId }}">
                                 {{ query.sql|doctrine_pretty_query() }}
                                 <div>
                                     <strong class="font-normal text-small">Parameters</strong>: {{ query.params|yaml_encode }}
                                 </div>
-                            </div>   
+                            </div>
                         {% endif %}
                     </div>
                     <div class="tree__col">


### PR DESCRIPTION
Show code snippet to view runnable query, rendering something like in Doctrine Profiler

## In default queries table
![image](https://user-images.githubusercontent.com/17051512/59073005-6c64f000-88c5-11e9-9c16-6ca1a104fa21.png)

## In stacktrace tree
![image](https://user-images.githubusercontent.com/17051512/59073021-88689180-88c5-11e9-89b2-c59f66319357.png)
