### PR TITLE
Cast query parameters as string

### DIFF
--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -4,7 +4,7 @@ namespace Pixers\DoctrineProfilerBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * ProfilerController.
@@ -17,16 +17,13 @@ class ProfilerController
      * @var Profiler
      */
     private $profiler;
+    /** @var Environment */
+    private $twig;
 
-    /**
-     * @var EngineInterface
-     */
-    private $templating;
-
-    public function __construct(Profiler $profiler, EngineInterface $templating)
+    public function __construct(Profiler $profiler, Environment $twig)
     {
         $this->profiler = $profiler;
-        $this->templating = $templating;
+        $this->twig = $twig;
     }
 
     /**
@@ -34,10 +31,8 @@ class ProfilerController
      *
      * @param string $token The profiler token
      * @param string $id
-     *
-     * @return Response A Response instance
      */
-    public function traceAction($token, $id)
+    public function traceAction($token, $id): Response
     {
         $this->profiler->disable();
         $profile = $this->profiler->loadProfile($token);
@@ -55,11 +50,17 @@ class ProfilerController
             }
         }
 
-        return $this->templating->renderResponse('PixersDoctrineProfilerBundle:Collector:trace.html.twig', array(
-            'source' => $source,
-            'traces' => $query['trace'],
-            'id' => $id,
-            'prefix' => $id,
-        ));
+        return new Response(
+            $this->twig
+                ->render(
+                    'PixersDoctrineProfilerBundle:Collector:trace.html.twig',
+                    [
+                        'source' => $source,
+                        'traces' => $query['trace'],
+                        'id' => $id,
+                        'prefix' => $id,
+                    ]
+                )
+        );
     }
 }

--- a/DependencyInjection/Compiler/EntityManagersCompilerPass.php
+++ b/DependencyInjection/Compiler/EntityManagersCompilerPass.php
@@ -2,8 +2,10 @@
 
 namespace Pixers\DoctrineProfilerBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -15,7 +17,52 @@ class EntityManagersCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $container->getDefinition('doctrine.dbal.logger.chain')
-                ->addMethodCall('addLogger', [new Reference('pixers_doctrine_profiler.logger')]);
+        $connections = $container->getParameter('doctrine.connections');
+
+        foreach ($connections as $name => $serviceId) {
+            $backtraceLoggerId = 'doctrine.dbal.logger.backtrace.'.$name;
+            $profilingLoggerId = 'doctrine.dbal.logger.profiling.'.$name;
+            $chainLoggerId = 'doctrine.dbal.logger.chain.'.$name;
+
+            if (
+                !$container->hasDefinition($chainLoggerId)
+                || (!$container->hasDefinition($backtraceLoggerId) && !$container->hasDefinition($profilingLoggerId))
+            ) {
+                // No profiler for this connection
+                continue;
+            }
+
+            $loggerId = 'pixers_doctrine_profiler.logger.'.$name;
+
+            $loggerDefinition = $this->getLoggerDefinition();
+            $container->setDefinition($loggerId, $loggerDefinition);
+
+            $logger = new Reference($loggerId);
+            $container->getDefinition($chainLoggerId)
+                ->addMethodCall('addLogger', array($logger));
+
+            $container->getDefinition('pixers_doctrine_profiler.data_collector')
+                ->addMethodCall('addLogger', array($name, $logger));
+
+            $entityManagerDefinition = $container->getDefinition(sprintf('doctrine.orm.%s_entity_manager', $name));
+
+            // Argument 0 is a Pixers entity manager
+            $container->getDefinition($entityManagerDefinition->getArgument(0))
+                ->addMethodCall('setLogger', array($logger));
+        }
+    }
+
+    /**
+     * @return ChildDefinition|DefinitionDecorator
+     */
+    private function getLoggerDefinition()
+    {
+        if (class_exists(DefinitionDecorator::class)) {
+            $childDefinition = new DefinitionDecorator('pixers_doctrine_profiler.logger');
+        } else {
+            $childDefinition = new ChildDefinition('pixers_doctrine_profiler.logger');
+        }
+
+        return $childDefinition;
     }
 }

--- a/DependencyInjection/Compiler/EntityManagersCompilerPass.php
+++ b/DependencyInjection/Compiler/EntityManagersCompilerPass.php
@@ -46,8 +46,7 @@ class EntityManagersCompilerPass implements CompilerPassInterface
 
             $entityManagerDefinition = $container->getDefinition(sprintf('doctrine.orm.%s_entity_manager', $name));
 
-            // Argument 0 is a Pixers entity manager
-            $container->getDefinition($entityManagerDefinition->getArgument(0))
+            $container->getDefinition('doctrine.orm.entity_manager.abstract')
                 ->addMethodCall('setLogger', array($logger));
         }
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,7 +19,7 @@
     <service id="pixers_doctrine_profiler.profiler_controller" class="Pixers\DoctrineProfilerBundle\Controller\ProfilerController">
       <tag name="controller.service_arguments"/>
       <argument type="service" id="profiler" />
-      <argument type="service" id="templating" />
+      <argument type="service" id="twig" />
     </service>
   </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
-    <service id="pixers_doctrine_profiler.logger" class="Pixers\DoctrineProfilerBundle\Logging\StackTraceLogger"/>
+    <service id="pixers_doctrine_profiler.logger" class="Pixers\DoctrineProfilerBundle\Logging\StackTraceLogger" abstract="true"/>
     <service id="doctrine.orm.entity_manager.abstract" class="Pixers\DoctrineProfilerBundle\ORM\EntityManager">
       <call method="setStopWatch">
         <argument type="service" id="debug.stopwatch"/>
-      </call>
-      <call method="setLogger">
-        <argument type="service" id="pixers_doctrine_profiler.logger"/>
       </call>
       <factory class="Pixers\DoctrineProfilerBundle\ORM\EntityManager" method="create"/>
     </service>
     <service id="pixers_doctrine_profiler.data_collector" class="Pixers\DoctrineProfilerBundle\DataCollector\QueryCollector" public="false">
       <tag name="data_collector" template="@PixersDoctrineProfiler/Collector/profiler.html.twig" id="doctrine_profiler"/>
-      <argument type="service" id="pixers_doctrine_profiler.logger"/>
       <argument type="service" id="debug.stopwatch"/>
+      <argument type="service" id="doctrine" />
     </service>
     <service id="pixers_doctrine_profiler.twig_extension" class="Pixers\DoctrineProfilerBundle\Twig\DoctrineProfilerExtension">
       <tag name="twig.extension"/>

--- a/Resources/views/Collector/profiler.html.twig
+++ b/Resources/views/Collector/profiler.html.twig
@@ -65,6 +65,7 @@
     {% set total_time = total_hydration_time + total_query_time %}
     {% set total_memory = collector.memoryusage %}
     {% set queries = collector.queries %}
+    {% set connections_count = collector.connectionsCount %}
     <div class="metrics">
         <div class="metric">
             <span class="value">{{ collector.count }}</span>
@@ -153,6 +154,11 @@
                         <div>
                             <strong class="font-normal text-small">Parameters</strong>: {{ query.params|yaml_encode }}
                         </div>
+                        {% if connections_count > 1 %}
+                            <div>
+                                <strong class="font-normal text-small">Connection</strong>: {{ query.connection }}
+                            </div>
+                        {% endif %}
                         <div class="text-small font-normal">
                             <a href="#" class="text-small" onclick="openTree('[data-query={{ '"'~i~'"' }}]');return false;">Jump to callgraph</a> &nbsp;&nbsp;
                             <a href="#" onclick="Popup.load('#original-query-{{ queryId }}');return false;">View runnable query</a>&nbsp;&nbsp;

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
         "doctrine/orm": "~2.5",
         "doctrine/doctrine-bundle": "~1.6",
         "symfony/framework-bundle": "~2.8 || ~3.4 || ~4.1",
-        "symfony/stopwatch": "~2.8 || ~3.4 || ~4.1"
+        "symfony/stopwatch": "~2.8 || ~3.4 || ~4.1",
+        "symfony/twig-bundle": "~2.8 || ~3.4 || ~4.1",
+        "twig/twig": "^1.38 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0"


### PR DESCRIPTION
Fix #12 

This also add information about connection's name in case of [multiple entity managers](https://symfony.com/doc/current/doctrine/multiple_entity_managers.html)

![image](https://user-images.githubusercontent.com/17051512/59368407-71e78d80-8d3e-11e9-9b06-993c66bf0a35.png)

Queries are also sorted by execution order, regardless the connection

@ojrzenski For what I've tested, this works on my main project with Symfony 2.8 but I can't test it on newer versions (by now)