### PR TITLE
Use Twig explicitly

### DIFF
--- a/Controller/ProfilerController.php
+++ b/Controller/ProfilerController.php
@@ -4,7 +4,7 @@ namespace Pixers\DoctrineProfilerBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * ProfilerController.
@@ -17,16 +17,13 @@ class ProfilerController
      * @var Profiler
      */
     private $profiler;
+    /** @var Environment */
+    private $twig;
 
-    /**
-     * @var EngineInterface
-     */
-    private $templating;
-
-    public function __construct(Profiler $profiler, EngineInterface $templating)
+    public function __construct(Profiler $profiler, Environment $twig)
     {
         $this->profiler = $profiler;
-        $this->templating = $templating;
+        $this->twig = $twig;
     }
 
     /**
@@ -34,10 +31,8 @@ class ProfilerController
      *
      * @param string $token The profiler token
      * @param string $id
-     *
-     * @return Response A Response instance
      */
-    public function traceAction($token, $id)
+    public function traceAction($token, $id): Response
     {
         $this->profiler->disable();
         $profile = $this->profiler->loadProfile($token);
@@ -55,11 +50,17 @@ class ProfilerController
             }
         }
 
-        return $this->templating->renderResponse('PixersDoctrineProfilerBundle:Collector:trace.html.twig', array(
-            'source' => $source,
-            'traces' => $query['trace'],
-            'id' => $id,
-            'prefix' => $id,
-        ));
+        return new Response(
+            $this->twig
+                ->render(
+                    'PixersDoctrineProfilerBundle:Collector:trace.html.twig',
+                    [
+                        'source' => $source,
+                        'traces' => $query['trace'],
+                        'id' => $id,
+                        'prefix' => $id,
+                    ]
+                )
+        );
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -22,7 +22,7 @@
     <service id="pixers_doctrine_profiler.profiler_controller" class="Pixers\DoctrineProfilerBundle\Controller\ProfilerController">
       <tag name="controller.service_arguments"/>
       <argument type="service" id="profiler" />
-      <argument type="service" id="templating" />
+      <argument type="service" id="twig" />
     </service>
   </services>
 </container>

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
         "doctrine/orm": "~2.5",
         "doctrine/doctrine-bundle": "~1.6",
         "symfony/framework-bundle": "~2.8 || ~3.4 || ~4.1",
-        "symfony/stopwatch": "~2.8 || ~3.4 || ~4.1"
+        "symfony/stopwatch": "~2.8 || ~3.4 || ~4.1",
+        "symfony/twig-bundle": "~2.8 || ~3.4 || ~4.1",
+        "twig/twig": "^1.38 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0"


### PR DESCRIPTION
As reported in #14 service `templating` can be missing, but when it is not missing it is deprecated anyway. This PR changes `ProfilerController`'s `EngineInterface` dependency to `Twig\Environment` to stop using deprecated `templating`.